### PR TITLE
ブラウザ復元時のスコア下書き復元を修正

### DIFF
--- a/app/submit-score/page.tsx
+++ b/app/submit-score/page.tsx
@@ -92,12 +92,24 @@ export default function SubmitScorePage() {
   } = useHoleData({ externalRoundCount: roundData.round_count })
 
   useEffect(() => {
-    const draft = loadScoreDraft()
-    if (draft) {
-      setPendingDraft(draft)
-    } else {
+    const checkForSavedDraft = () => {
+      const draft = loadScoreDraft()
+      if (draft) {
+        // A browser may restore this page from its back/forward cache without
+        // remounting the component. Pause autosaving before showing the saved
+        // draft so the reset in-memory state cannot overwrite it.
+        setDraftReady(false)
+        setPendingDraft(draft)
+        return
+      }
+
       setDraftReady(true)
     }
+
+    checkForSavedDraft()
+    window.addEventListener("pageshow", checkForSavedDraft)
+
+    return () => window.removeEventListener("pageshow", checkForSavedDraft)
   }, [])
 
   useEffect(() => {
@@ -131,8 +143,19 @@ export default function SubmitScorePage() {
       saveScoreDraft({ roundData, performanceData, holes, currentHole, activeTab })
     }
 
+    const saveWhenHidden = () => {
+      if (document.visibilityState === "hidden") saveBeforePageExit()
+    }
+
+    // Mobile browsers can be terminated after moving to the background
+    // without firing pagehide/unload. visibilitychange is the last reliable
+    // opportunity to persist the current input in that case.
     window.addEventListener("pagehide", saveBeforePageExit)
-    return () => window.removeEventListener("pagehide", saveBeforePageExit)
+    document.addEventListener("visibilitychange", saveWhenHidden)
+    return () => {
+      window.removeEventListener("pagehide", saveBeforePageExit)
+      document.removeEventListener("visibilitychange", saveWhenHidden)
+    }
   }, [activeTab, currentHole, draftReady, holes, performanceData, roundData])
 
   const restoreDraft = () => {


### PR DESCRIPTION
### Motivation
- ブラウザのセッション復元（Back/Forward Cache 等）でコンポーネントが再マウントされない場合に、保存済み下書きの確認が遅れて入力が上書きされる問題を解消するための修正です。

### Description
- `app/submit-score/page.tsx` に `checkForSavedDraft` を追加し、マウント時と `pageshow` イベントで保存済み下書きを再確認して復元ダイアログを即時表示するようにしました。
- 保存済み下書きを検出した際は自動保存を一時停止するために `setDraftReady(false)` を呼び出してメモリ上の初期化処理で下書きが上書きされないようにしました（検出後は `setPendingDraft` を設定）。
- モバイルブラウザがバックグラウンド移行で `pagehide` を発火しないケースに備え、`visibilitychange` を監視して `document.visibilityState === "hidden"` のときにも `saveScoreDraft` を呼ぶようにして保存機会を増やしました。
- 追加したイベントリスナの登録・解除を適切に行うクリーンアップ処理を実装しました。

### Testing
- `git diff --check` を実行して差分チェックは成功しました。
- 型チェックのために `pnpm exec tsc --noEmit` を実行しましたが、今回の変更箇所ではなく既存ファイルの構文エラーにより完走できませんでした（`components/RoundBasicInfoCard.tsx` の行179–186付近で構文エラーが発生）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a754800e7f4832b95a9f5a9dce2a787)