### PR TITLE
Add short-game metrics and round details dialog; adjust distance bands

### DIFF
--- a/app/player/[id]/page.tsx
+++ b/app/player/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import { useRouter, useParams } from "next/navigation";
 import {
@@ -30,11 +30,14 @@ import {
   GuitarIcon as Golf,
   Share2,
   MessageCircle,
+  ListChecks,
 } from "lucide-react";
 import { useLoadingNavigation } from "@/hooks/use-loading-navigation";
 import { LoadingModal } from "@/components/ui/loading-modal";
 import { ScoreReportModal } from "@/components/score/ScoreReportModal";
 import { getHoleMemos, HoleMemoListDialog } from "@/components/score/HoleMemoListDialog";
+import { calculateAverageShortGame } from "@/lib/short-game";
+import { RoundDetailsDialog } from "@/components/player/round-details-dialog";
 
 async function getPlayer(id: string) {
   const { data, error } = await supabase
@@ -91,6 +94,7 @@ export default function PlayerPage() {
   const [rounds, setRounds] = useState<Round[]>([]);
   const [loading, setLoading] = useState(true);
   const { isNavigating, navigate } = useLoadingNavigation();
+  const averageShortGame = useMemo(() => calculateAverageShortGame(rounds), [rounds]);
 
   // データの取得
   useEffect(() => {
@@ -311,6 +315,12 @@ export default function PlayerPage() {
                       icon={<Golf className="h-5 w-5 text-blue-500" />}
                     />
                     <StatCard
+                      title="平均SG"
+                      value={averageShortGame}
+                      decimals={1}
+                      icon={<Flag className="h-5 w-5 text-green-500" />}
+                    />
+                    <StatCard
                       title="ピン率"
                       value={stats.pin_rate}
                       decimals={1}
@@ -340,11 +350,11 @@ export default function PlayerPage() {
                           value={stats.dist_1_30}
                         />
                         <DistanceStatCard
-                          title="31-80m"
+                          title="31-100m"
                           value={stats.dist_31_80}
                         />
                         <DistanceStatCard
-                          title="81-120m"
+                          title="101-120m"
                           value={stats.dist_81_120}
                         />
                         <DistanceStatCard
@@ -473,6 +483,7 @@ function RoundCard({ round }: { round: Round }) {
   
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
   const [isMemoDialogOpen, setIsMemoDialogOpen] = useState(false);
+  const [isDetailsDialogOpen, setIsDetailsDialogOpen] = useState(false);
   const memoCount = getHoleMemos(round).length;
 
   const handleReportClick = (e: React.MouseEvent) => {
@@ -510,6 +521,18 @@ function RoundCard({ round }: { round: Round }) {
                     : ""}
                 </div>
                 <div className="flex flex-wrap justify-end gap-2 mt-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-xs border-golf-500 text-golf-600 hover:bg-golf-50"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setIsDetailsDialogOpen(true);
+                    }}
+                  >
+                    <ListChecks className="h-3 w-3 mr-1" />
+                    詳細
+                  </Button>
                   {memoCount > 0 && (
                     <Button
                       variant="outline"
@@ -578,6 +601,11 @@ function RoundCard({ round }: { round: Round }) {
       <ScoreReportModal
         isOpen={isReportModalOpen}
         onClose={() => setIsReportModalOpen(false)}
+        round={round}
+      />
+      <RoundDetailsDialog
+        open={isDetailsDialogOpen}
+        onOpenChange={setIsDetailsDialogOpen}
         round={round}
       />
       <HoleMemoListDialog

--- a/app/playerstats/page.tsx
+++ b/app/playerstats/page.tsx
@@ -8,6 +8,7 @@ import { PlayerWithStats } from "@/types/player-stats"
 import { BasicStatsTable } from "@/components/player-stats/basic-stats-table"
 import { DistanceStatsTable } from "@/components/player-stats/distance-stats-table"
 import { StatsFilter } from "@/components/player-stats/stats-filter"
+import { calculateAverageShortGame } from "@/lib/short-game"
 
 export default function PlayerStatsPage() {
   const [players, setPlayers] = useState<PlayerWithStats[]>([])
@@ -25,6 +26,12 @@ export default function PlayerStatsPage() {
         const { data: playersData, error: playersError } = await supabase.from("players").select("*").order("name")
 
         if (playersError) throw playersError
+
+        const { data: roundsData, error: roundsError } = await supabase
+          .from("rounds")
+          .select("player_id, holes, round_count")
+
+        if (roundsError) throw roundsError
 
         const playersWithStats: PlayerWithStats[] = []
 
@@ -46,7 +53,14 @@ export default function PlayerStatsPage() {
 
           playersWithStats.push({
             ...player,
-            stats: statsError ? null : statsData,
+            stats: statsError
+              ? null
+              : {
+                  ...statsData,
+                  avg_short_game: calculateAverageShortGame(
+                    roundsData.filter((round) => round.player_id === player.id),
+                  ),
+                },
             performance: perfError ? null : perfData
           })
         }
@@ -164,4 +178,3 @@ export default function PlayerStatsPage() {
     </div>
   )
 }
-

--- a/app/submit-score/page.tsx
+++ b/app/submit-score/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { supabase, type Player } from "@/lib/supabase"
+import { isGreenInRegulation } from "@/lib/short-game"
 import { Calendar, Cloud, Flag, GuitarIcon as Golf, Trophy, User } from "lucide-react"
 
 // コンポーネントとフックをインポート
@@ -232,7 +233,7 @@ export default function SubmitScorePage() {
       }
 
       // グリーンヒット
-      if (hole.score <= hole.par) {
+      if (isGreenInRegulation(hole)) {
         performance.par_on += 1
       }
       if (hole.score === hole.par + 1) {

--- a/components/player-stats/basic-stats-table.tsx
+++ b/components/player-stats/basic-stats-table.tsx
@@ -41,6 +41,15 @@ export function BasicStatsTable({ players, sortField, sortDirection, onSort }: B
                 平均パット {sortField === "avg_putt" && (sortDirection === "asc" ? "↑" : "↓")}
               </div>
             </TableHead>
+            <TableHead
+              className="cursor-pointer font-semibold text-gray-700 hover:text-golf-600 text-right"
+              onClick={() => onSort("avg_short_game")}
+            >
+              <div className="flex items-center justify-end">
+                <Flag className="h-4 w-4 mr-1 text-green-500" />
+                平均SG {sortField === "avg_short_game" && (sortDirection === "asc" ? "↑" : "↓")}
+              </div>
+            </TableHead>
             
             {/* Performance Table から統合 - 1パット */}
             <TableHead
@@ -130,6 +139,15 @@ export function BasicStatsTable({ players, sortField, sortDirection, onSort }: B
                 {player.stats?.avg_putt !== undefined && player.stats?.avg_putt !== null ? (
                   <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">
                     {player.stats.avg_putt.toFixed(1)}
+                  </Badge>
+                ) : (
+                  "-"
+                )}
+              </TableCell>
+              <TableCell className="text-right font-medium">
+                {player.stats?.avg_short_game != null ? (
+                  <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+                    {player.stats.avg_short_game.toFixed(1)}
                   </Badge>
                 ) : (
                   "-"

--- a/components/player-stats/distance-stats-table.tsx
+++ b/components/player-stats/distance-stats-table.tsx
@@ -50,7 +50,7 @@ export function DistanceStatsTable({ players, sortField, sortDirection, onSort }
             >
               <div className="flex items-center justify-end">
                 <Trophy className="h-4 w-4 mr-1 text-amber-500" />
-                31-80m {sortField === "dist_31_80" && (sortDirection === "asc" ? "↑" : "↓")}
+                31-100m {sortField === "dist_31_80" && (sortDirection === "asc" ? "↑" : "↓")}
               </div>
             </TableHead>
             <TableHead 
@@ -59,7 +59,7 @@ export function DistanceStatsTable({ players, sortField, sortDirection, onSort }
             >
               <div className="flex items-center justify-end">
                 <Trophy className="h-4 w-4 mr-1 text-amber-500" />
-                81-120m {sortField === "dist_81_120" && (sortDirection === "asc" ? "↑" : "↓")}
+                101-120m {sortField === "dist_81_120" && (sortDirection === "asc" ? "↑" : "↓")}
               </div>
             </TableHead>
             <TableHead 

--- a/components/player/round-details-dialog.tsx
+++ b/components/player/round-details-dialog.tsx
@@ -1,0 +1,52 @@
+import type { Round } from "@/lib/supabase"
+import { calculateRoundDetails } from "@/lib/round-details"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+
+type RoundDetailsDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  round: Round
+}
+
+const detailItems = [
+  { key: "putts", label: "パット" },
+  { key: "threePuttsOrMore", label: "3パット以上" },
+  { key: "fairwayKeeps", label: "FWキープ" },
+  { key: "ob", label: "OB" },
+  { key: "parOns", label: "パーオン" },
+  { key: "bogeyOns", label: "ボギーオン" },
+  { key: "shortGame", label: "SG" },
+] as const
+
+export function RoundDetailsDialog({ open, onOpenChange, round }: RoundDetailsDialogProps) {
+  const details = calculateRoundDetails(round)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>ラウンド詳細</DialogTitle>
+          <DialogDescription>
+            {round.club_name || "コース名なし"}・{round.date ? new Date(round.date).toLocaleDateString("ja-JP") : "日付なし"}
+          </DialogDescription>
+        </DialogHeader>
+
+        {details ? (
+          <div className="grid grid-cols-2 overflow-hidden rounded-lg border border-gray-200 sm:grid-cols-4 lg:grid-cols-7">
+            {detailItems.map((item) => (
+              <div key={item.key} className="border-b border-r border-gray-200 bg-white p-3 text-center last:border-r-0">
+                <div className="min-h-10 text-sm font-medium text-gray-600">{item.label}</div>
+                <div className="mt-2 text-2xl font-bold text-golf-800">{details[item.key]}</div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg bg-gray-50 p-6 text-center text-sm text-gray-500">
+            このラウンドには詳細なホール情報がありません。
+          </div>
+        )}
+        <p className="text-xs text-gray-500">SGはパーオンを除く100m以内のショットとパットの合計です。</p>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/score/ApproachShotInput.tsx
+++ b/components/score/ApproachShotInput.tsx
@@ -64,7 +64,7 @@ export function ApproachShotInput({
           </div>
         </FormField>
 
-        <FormField label="31~80m">
+        <FormField label="31~100m">
           <div className="flex items-center justify-start gap-2">
             <Button 
               variant="outline" 
@@ -93,7 +93,7 @@ export function ApproachShotInput({
           </div>
         </FormField>
 
-        <FormField label="81~120m">
+        <FormField label="101~120m">
           <div className="flex items-center justify-start gap-2">
             <Button 
               variant="outline" 

--- a/components/score/PerformanceTabContent.tsx
+++ b/components/score/PerformanceTabContent.tsx
@@ -163,7 +163,7 @@ export function PerformanceTabContent({
           />
 
           <DistanceInputGroup
-            title="31-80m"
+            title="31-100m"
             successValue={getInputValue(performanceData.dist_31_80_success)}
             totalValue={getInputValue(performanceData.dist_31_80_total)}
             onSuccessChange={(value) => handlePerformanceChange("dist_31_80_success", value)}
@@ -171,7 +171,7 @@ export function PerformanceTabContent({
           />
 
           <DistanceInputGroup
-            title="81-120m"
+            title="101-120m"
             successValue={getInputValue(performanceData.dist_81_120_success)}
             totalValue={getInputValue(performanceData.dist_81_120_total)}
             onSuccessChange={(value) => handlePerformanceChange("dist_81_120_success", value)}

--- a/hooks/use-performance-calculator.ts
+++ b/hooks/use-performance-calculator.ts
@@ -1,6 +1,7 @@
 import { type HoleData } from "@/types/score"
 import { type Performance } from "@/lib/supabase"
 import { useRef, useCallback } from "react"
+import { isGreenInRegulation } from "@/lib/short-game"
 
 type PerformanceCalculatorProps = {
   holes: HoleData[]
@@ -78,7 +79,7 @@ export function usePerformanceCalculator({ holes, handleRoundChange }: Performan
       }
 
       // グリーンヒット
-      if (hole.score <= hole.par) {
+      if (isGreenInRegulation(hole)) {
         performance.par_on! += 1
       }
       if (hole.score === hole.par + 1) {

--- a/lib/round-details.ts
+++ b/lib/round-details.ts
@@ -1,0 +1,42 @@
+import type { Json } from "@/lib/database.types"
+import type { Round } from "@/lib/supabase"
+import type { HoleData } from "@/types/score"
+import { calculateRoundShortGame, isGreenInRegulation } from "@/lib/short-game"
+
+export type RoundDetailMetrics = {
+  putts: number
+  threePuttsOrMore: number
+  fairwayKeeps: number
+  ob: number
+  parOns: number
+  bogeyOns: number
+  shortGame: number
+}
+
+function isDetailHole(value: Json): value is Json & HoleData & { ob2nd?: number } {
+  if (!value || Array.isArray(value) || typeof value !== "object") return false
+  const hole = value as Record<string, Json | undefined>
+  return typeof hole.par === "number" && typeof hole.score === "number" && typeof hole.putts === "number"
+}
+
+export function calculateRoundDetails(round: Pick<Round, "holes" | "putts">): RoundDetailMetrics | null {
+  if (!round.holes || round.holes.length === 0 || !round.holes.every(isDetailHole)) return null
+
+  const metrics = round.holes.reduce<RoundDetailMetrics>(
+    (result, hole) => {
+      const strokesBeforePutting = hole.score - hole.putts
+      result.putts += hole.putts
+      result.threePuttsOrMore += hole.putts >= 3 ? 1 : 0
+      result.fairwayKeeps += hole.fairwayHit ? 1 : 0
+      result.ob += (hole.ob1w ?? 0) + (hole.obOther ?? 0) + (hole.ob2nd ?? 0)
+      result.parOns += isGreenInRegulation(hole) ? 1 : 0
+      result.bogeyOns += strokesBeforePutting === hole.par - 1 ? 1 : 0
+      return result
+    },
+    { putts: 0, threePuttsOrMore: 0, fairwayKeeps: 0, ob: 0, parOns: 0, bogeyOns: 0, shortGame: 0 },
+  )
+
+  metrics.putts = round.putts ?? metrics.putts
+  metrics.shortGame = calculateRoundShortGame(round.holes) ?? 0
+  return metrics
+}

--- a/lib/short-game.ts
+++ b/lib/short-game.ts
@@ -1,0 +1,45 @@
+import type { Json } from "@/lib/database.types"
+import type { HoleData } from "@/types/score"
+
+type RoundForShortGame = {
+  holes: Json[] | null
+  round_count: number | null
+}
+
+function isHoleData(value: Json): value is Json & HoleData {
+  if (!value || Array.isArray(value) || typeof value !== "object") return false
+
+  const hole = value as Record<string, Json | undefined>
+  return typeof hole.par === "number" && typeof hole.score === "number" && typeof hole.putts === "number"
+}
+
+/** A GIR is reached when strokes before putting are no more than par minus two. */
+export function isGreenInRegulation(hole: Pick<HoleData, "par" | "score" | "putts">): boolean {
+  if (hole.par <= 0 || hole.score <= 0 || hole.putts < 0 || hole.putts > hole.score) return false
+  return hole.score - hole.putts <= hole.par - 2
+}
+
+/** Counts shots from 100m and in, including putts, on holes where GIR was missed. */
+export function calculateRoundShortGame(holes: Json[] | null): number | null {
+  if (!holes || holes.length === 0 || !holes.every(isHoleData)) return null
+
+  return holes.reduce((total, hole) => {
+    if (isGreenInRegulation(hole)) return total
+    return total + (hole.shotCount30 ?? 0) + (hole.shotCount80 ?? 0) + hole.putts
+  }, 0)
+}
+
+/** Calculates the per-round average, including multi-round score entries. */
+export function calculateAverageShortGame(rounds: RoundForShortGame[]): number | null {
+  let totalShots = 0
+  let totalRounds = 0
+
+  rounds.forEach((round) => {
+    const shortGame = calculateRoundShortGame(round.holes)
+    if (shortGame === null) return
+    totalShots += shortGame
+    totalRounds += round.round_count && round.round_count > 0 ? round.round_count : 1
+  })
+
+  return totalRounds > 0 ? totalShots / totalRounds : null
+}

--- a/types/player-stats.ts
+++ b/types/player-stats.ts
@@ -1,6 +1,6 @@
 import { Player, PlayerStats, Performance } from "@/lib/supabase"
 
 export interface PlayerWithStats extends Player {
-  stats: PlayerStats | null
+  stats: (PlayerStats & { avg_short_game?: number | null }) | null
   performance: Performance | null
 }


### PR DESCRIPTION
### Motivation

- Provide a short-game (SG) metric aggregated per-round and averaged across rounds to help analyze shots inside 100m plus putts when GIR is missed.
- Expose per-round detailed metrics in the UI so users can view putts, OB, FW keeps, SG and other key counts for each round.
- Unify GIR detection and short-game logic in a reusable library and ensure performance calculations use the same GIR rule.

### Description

- Add `lib/short-game.ts` with `isGreenInRegulation`, `calculateRoundShortGame`, and `calculateAverageShortGame` to centralize SG logic and GIR detection.
- Add `lib/round-details.ts` to compute per-round detail metrics and a new UI component `components/player/round-details-dialog.tsx` to display them in a dialog.
- Wire the Round Details dialog into `app/player/[id]/page.tsx` by adding a "詳細" button to each `RoundCard` and computing `averageShortGame` via `calculateAverageShortGame` to show as a StatCard.
- Compute and surface per-player `avg_short_game` in `app/playerstats/page.tsx` by fetching rounds and attaching the calculated average to the `PlayerWithStats` object, and extend `types/player-stats.ts` accordingly.
- Replace inline GIR checks (`hole.score <= hole.par`) with `isGreenInRegulation` across performance calculation logic in `hooks/use-performance-calculator.ts` and `app/submit-score/page.tsx` to standardize behavior.
- Update UI labels and inputs for distance bands from `31-80m`/`81-120m` to `31-100m`/`101-120m` in `ApproachShotInput.tsx`, `PerformanceTabContent.tsx`, `DistanceStatsTable.tsx` and other related components.
- Add `avg_short_game` column and sorting support to the basic stats table (`components/player-stats/basic-stats-table.tsx`) and show the value with a badge in the player list.

### Testing

- Performed a TypeScript build/type-check using the project build (`next build`) which completed successfully.
- Ran the existing automated test suite (`yarn test`) and it completed without failures (no new unit tests were added as part of this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8688714e84832ba9a62fae2245105d)