### PR TITLE
Calculate short game averages per missed green

### DIFF
--- a/components/player/round-details-dialog.tsx
+++ b/components/player/round-details-dialog.tsx
@@ -36,7 +36,13 @@ export function RoundDetailsDialog({ open, onOpenChange, round }: RoundDetailsDi
             {detailItems.map((item) => (
               <div key={item.key} className="border-b border-r border-gray-200 bg-white p-3 text-center last:border-r-0">
                 <div className="min-h-10 text-sm font-medium text-gray-600">{item.label}</div>
-                <div className="mt-2 text-2xl font-bold text-golf-800">{details[item.key]}</div>
+                <div className="mt-2 text-2xl font-bold text-golf-800">
+                  {item.key === "shortGame"
+                    ? details.shortGame === null
+                      ? "—"
+                      : details.shortGame.toFixed(1)
+                    : details[item.key]}
+                </div>
               </div>
             ))}
           </div>
@@ -45,7 +51,9 @@ export function RoundDetailsDialog({ open, onOpenChange, round }: RoundDetailsDi
             このラウンドには詳細なホール情報がありません。
           </div>
         )}
-        <p className="text-xs text-gray-500">SGはパーオンを除く100m以内のショットとパットの合計です。</p>
+        <p className="text-xs text-gray-500">
+          SGはパーオンしていない1ホールあたりの、100m以内のショットとパットの平均打数です。
+        </p>
       </DialogContent>
     </Dialog>
   )

--- a/lib/round-details.ts
+++ b/lib/round-details.ts
@@ -10,7 +10,7 @@ export type RoundDetailMetrics = {
   ob: number
   parOns: number
   bogeyOns: number
-  shortGame: number
+  shortGame: number | null
 }
 
 function isDetailHole(value: Json): value is Json & HoleData & { ob2nd?: number } {
@@ -37,6 +37,6 @@ export function calculateRoundDetails(round: Pick<Round, "holes" | "putts">): Ro
   )
 
   metrics.putts = round.putts ?? metrics.putts
-  metrics.shortGame = calculateRoundShortGame(round.holes) ?? 0
+  metrics.shortGame = calculateRoundShortGame(round.holes)
   return metrics
 }

--- a/lib/short-game.ts
+++ b/lib/short-game.ts
@@ -6,6 +6,11 @@ type RoundForShortGame = {
   round_count: number | null
 }
 
+export type ShortGameTotals = {
+  shortGameShots: number
+  missedGreenHoles: number
+}
+
 function isHoleData(value: Json): value is Json & HoleData {
   if (!value || Array.isArray(value) || typeof value !== "object") return false
 
@@ -19,27 +24,41 @@ export function isGreenInRegulation(hole: Pick<HoleData, "par" | "score" | "putt
   return hole.score - hole.putts <= hole.par - 2
 }
 
-/** Counts shots from 100m and in, including putts, on holes where GIR was missed. */
-export function calculateRoundShortGame(holes: Json[] | null): number | null {
+/** Totals shots and holes used to calculate short game performance. */
+export function calculateShortGameTotals(holes: Json[] | null): ShortGameTotals | null {
   if (!holes || holes.length === 0 || !holes.every(isHoleData)) return null
 
-  return holes.reduce((total, hole) => {
-    if (isGreenInRegulation(hole)) return total
-    return total + (hole.shotCount30 ?? 0) + (hole.shotCount80 ?? 0) + hole.putts
-  }, 0)
+  return holes.reduce<ShortGameTotals>(
+    (totals, hole) => {
+      if (isGreenInRegulation(hole)) return totals
+
+      totals.shortGameShots += (hole.shotCount30 ?? 0) + (hole.shotCount80 ?? 0) + hole.putts
+      totals.missedGreenHoles += 1
+      return totals
+    },
+    { shortGameShots: 0, missedGreenHoles: 0 },
+  )
 }
 
-/** Calculates the per-round average, including multi-round score entries. */
+/** Calculates average short game shots per missed-GIR hole for a round. */
+export function calculateRoundShortGame(holes: Json[] | null): number | null {
+  const totals = calculateShortGameTotals(holes)
+  if (!totals || totals.missedGreenHoles === 0) return null
+
+  return totals.shortGameShots / totals.missedGreenHoles
+}
+
+/** Calculates the missed-GIR-hole-weighted average across rounds. */
 export function calculateAverageShortGame(rounds: RoundForShortGame[]): number | null {
   let totalShots = 0
-  let totalRounds = 0
+  let totalMissedGreenHoles = 0
 
   rounds.forEach((round) => {
-    const shortGame = calculateRoundShortGame(round.holes)
-    if (shortGame === null) return
-    totalShots += shortGame
-    totalRounds += round.round_count && round.round_count > 0 ? round.round_count : 1
+    const totals = calculateShortGameTotals(round.holes)
+    if (!totals) return
+    totalShots += totals.shortGameShots
+    totalMissedGreenHoles += totals.missedGreenHoles
   })
 
-  return totalRounds > 0 ? totalShots / totalRounds : null
+  return totalMissedGreenHoles > 0 ? totalShots / totalMissedGreenHoles : null
 }


### PR DESCRIPTION
### Motivation

- Replace the prior SG calculation that summed per-round totals with a structure that separately tracks the numerator (shots) and denominator (non-GIR holes) so SG represents shots per missed-GIR hole. 
- Ensure per-round SG is `null` when there are no missed-GIR holes or when hole data is invalid, and make aggregated average SG a missed-GIR-hole-weighted average across rounds.

### Description

- Add `ShortGameTotals` and `calculateShortGameTotals(holes)` to accumulate `shortGameShots` and `missedGreenHoles` for a round. 
- Change `calculateRoundShortGame` to return `shortGameShots / missedGreenHoles` or `null` when `missedGreenHoles === 0` or holes are invalid. 
- Change `calculateAverageShortGame` to compute a weighted average by dividing the sum of all rounds' `shortGameShots` by the sum of all rounds' `missedGreenHoles` (no use of `round_count` as a direct denominator). 
- Update `RoundDetailMetrics.shortGame` to `number | null` and stop coercing `null` to `0` in `calculateRoundDetails`. 
- Update the round details UI to display SG with one decimal place, show `—` when SG is `null`, and update the explanatory text to: “SGはパーオンしていない1ホールあたりの、100m以内のショットとパットの平均打数です。”

### Testing

- Ran node assertions exercising `calculateShortGameTotals`, `calculateRoundShortGame`, and multi-round weighting, and they passed (`short-game assertions passed`).
- Ran `git diff --check` and repository diffs were clean with the expected changes. 
- Ran `pnpm build`; the app compiled but prerendering failed due to missing Supabase environment variables (warning). 
- Ran `pnpm exec tsc --noEmit`; TypeScript reported pre-existing type errors outside the modified files so a full type-check could not be completed (warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8967297a20832ba1ad11df7635f457)