### PR TITLE
コース名を必須項目から外して未入力でも送信できるように

### DIFF
--- a/hooks/use-score-data.ts
+++ b/hooks/use-score-data.ts
@@ -88,10 +88,6 @@ export function useScoreData({ onSubmitSuccess }: UseScoreDataOptions = {}) {
       missingFields.push("日付");
     }
     
-    if (!roundData.course_name) {
-      missingFields.push("コース名");
-    }
-
     if (missingFields.length > 0) {
       // toastの代わりにalertを使用
       alert(`入力エラー: 以下の項目を入力してください: ${missingFields.join(", ")}`);


### PR DESCRIPTION
フォーム上は「コース名（オプション）」と表示されているのに、
スコア登録時のバリデーションで course_name が必須になっており
未入力だと送信できなかったため、チェックを削除。
DB 上も course_name は nullable。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbjExBrVyFDrzhNtkg1HaK