### PR TITLE
Exclude holes without short-game shots from SG

### DIFF
--- a/lib/short-game.ts
+++ b/lib/short-game.ts
@@ -24,7 +24,7 @@ export function isGreenInRegulation(hole: Pick<HoleData, "par" | "score" | "putt
   return hole.score - hole.putts <= hole.par - 2
 }
 
-/** Totals shots and holes used to calculate short game performance. */
+/** Totals shots and eligible missed-GIR holes used to calculate short game performance. */
 export function calculateShortGameTotals(holes: Json[] | null): ShortGameTotals | null {
   if (!holes || holes.length === 0 || !holes.every(isHoleData)) return null
 
@@ -32,7 +32,10 @@ export function calculateShortGameTotals(holes: Json[] | null): ShortGameTotals 
     (totals, hole) => {
       if (isGreenInRegulation(hole)) return totals
 
-      totals.shortGameShots += (hole.shotCount30 ?? 0) + (hole.shotCount80 ?? 0) + hole.putts
+      const approachShots = (hole.shotCount30 ?? 0) + (hole.shotCount80 ?? 0)
+      if (approachShots === 0) return totals
+
+      totals.shortGameShots += approachShots + hole.putts
       totals.missedGreenHoles += 1
       return totals
     },


### PR DESCRIPTION
### Motivation
- Exclude missed-GIR holes from short-game (SG) calculations when their combined `shotCount30 + shotCount80` is zero, so they do not contribute to either the shot total or the denominator.

### Description
- Update `calculateShortGameTotals` in `lib/short-game.ts` to compute `approachShots = (hole.shotCount30 ?? 0) + (hole.shotCount80 ?? 0)` and skip the hole when `approachShots === 0`, and adjust the function comment to reflect "eligible" missed-GIR holes.

### Testing
- Ran `git diff --check`, which succeeded. 
- Ran `pnpm exec tsc --noEmit`, which failed due to pre-existing TypeScript errors elsewhere in the repository and not related to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c1800dbc8832bb9f2d2dd1eb8bc8c)